### PR TITLE
Feat/add taxes crud

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Siga os passos abaixo para rodar a aplicação localmente:
 
 5. **Acesso á documentação Swagger**:
    - A documentação swagger estará disponível em: [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
+   - Registrar um usuário.
+   - Fazer login com o usuário registrado na base e copiar o JWT retornado.
+   - Autenticar pelo swagger usando o JWT no botão Authorize e colar o valor do JWT.
 
 ## 🧪 Como Rodar os Testes e Gerar Relatórios de Cobertura
 

--- a/src/main/java/br/com/zup/taxes/controllers/TaxController.java
+++ b/src/main/java/br/com/zup/taxes/controllers/TaxController.java
@@ -7,10 +7,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/impostos")
@@ -21,10 +25,19 @@ public class TaxController {
 
     @PostMapping("/tipos")
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<TaxResponseDto> register(@RequestBody TaxDto taxRequest){
+    public ResponseEntity<TaxResponseDto> register(@RequestBody TaxDto taxRequest) {
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(taxService.register(taxRequest));
     }
-}
+
+    @GetMapping("/tipos")
+    public ResponseEntity<List<TaxResponseDto>> findAll() {
+        return ResponseEntity.ok(taxService.findAll());
+    }
+
+    @GetMapping("/tipos/{id}")
+    public ResponseEntity<TaxResponseDto> findById(@PathVariable Long id) {
+        return ResponseEntity.ok(taxService.findById(id));
+    }}

--- a/src/main/java/br/com/zup/taxes/controllers/TaxController.java
+++ b/src/main/java/br/com/zup/taxes/controllers/TaxController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,4 +41,13 @@ public class TaxController {
     @GetMapping("/tipos/{id}")
     public ResponseEntity<TaxResponseDto> findById(@PathVariable Long id) {
         return ResponseEntity.ok(taxService.findById(id));
-    }}
+    }
+
+    @DeleteMapping("/tipos/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> deleteById(@PathVariable Long id) {
+        taxService.deleteById(id);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/src/main/java/br/com/zup/taxes/controllers/TaxController.java
+++ b/src/main/java/br/com/zup/taxes/controllers/TaxController.java
@@ -1,17 +1,30 @@
 package br.com.zup.taxes.controllers;
 
+import br.com.zup.taxes.controllers.dto.TaxDto;
+import br.com.zup.taxes.controllers.dto.TaxResponseDto;
+import br.com.zup.taxes.services.TaxService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/impostos")
+@RequiredArgsConstructor
 public class TaxController {
 
-    @GetMapping
+    private final TaxService taxService;
+
+    @PostMapping("/tipos")
     @PreAuthorize("hasRole('ADMIN')")
-    public String teste(){
-        return "Deu bom";
+    public ResponseEntity<TaxResponseDto> register(@RequestBody TaxDto taxRequest){
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(taxService.register(taxRequest));
     }
 }

--- a/src/main/java/br/com/zup/taxes/controllers/UserController.java
+++ b/src/main/java/br/com/zup/taxes/controllers/UserController.java
@@ -22,12 +22,14 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/registrar")
-    public ResponseEntity<ResponseRegisterUserDto> registerUser(@RequestBody RegisterUserDto registerUserDto){
-        return ResponseEntity.status(HttpStatus.CREATED).body(userService.register(registerUserDto));
+    public ResponseEntity<ResponseRegisterUserDto> registerUser(@RequestBody RegisterUserDto registerUserDto) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(userService.register(registerUserDto));
     }
 
     @PostMapping("/login")
-    public ResponseEntity<AuthResponseDto> login(@RequestBody LoginDto loginDto){
+    public ResponseEntity<AuthResponseDto> login(@RequestBody LoginDto loginDto) {
         AuthResponseDto responseDto = userService.login(loginDto);
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);

--- a/src/main/java/br/com/zup/taxes/controllers/dto/TaxDto.java
+++ b/src/main/java/br/com/zup/taxes/controllers/dto/TaxDto.java
@@ -1,0 +1,18 @@
+package br.com.zup.taxes.controllers.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TaxDto {
+    private String name;
+    private String description;
+    private Double aliquot;
+}

--- a/src/main/java/br/com/zup/taxes/controllers/dto/TaxResponseDto.java
+++ b/src/main/java/br/com/zup/taxes/controllers/dto/TaxResponseDto.java
@@ -1,0 +1,19 @@
+package br.com.zup.taxes.controllers.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TaxResponseDto {
+    private Long id;
+    private String name;
+    private String description;
+    private Double aliquot;
+}

--- a/src/main/java/br/com/zup/taxes/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/zup/taxes/exceptions/GlobalExceptionHandler.java
@@ -31,4 +31,15 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(TaxNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleTaxNotFoundException(TaxNotFoundException ex, HttpServletRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI()
+        );
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
 }

--- a/src/main/java/br/com/zup/taxes/exceptions/TaxNotFoundException.java
+++ b/src/main/java/br/com/zup/taxes/exceptions/TaxNotFoundException.java
@@ -1,0 +1,7 @@
+package br.com.zup.taxes.exceptions;
+
+public class TaxNotFoundException extends RuntimeException {
+    public TaxNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/br/com/zup/taxes/infra/CustomAccessDeniedHandler.java
+++ b/src/main/java/br/com/zup/taxes/infra/CustomAccessDeniedHandler.java
@@ -1,0 +1,33 @@
+package br.com.zup.taxes.infra;
+
+import br.com.zup.taxes.exceptions.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.FORBIDDEN.getReasonPhrase(),
+                "Acesso negado. Você não tem permissão para acessar este recurso.",
+                request.getRequestURI()
+        );
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/br/com/zup/taxes/infra/SecurityConfig.java
+++ b/src/main/java/br/com/zup/taxes/infra/SecurityConfig.java
@@ -11,7 +11,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -24,14 +24,15 @@ import org.springframework.stereotype.Component;
 @AllArgsConstructor
 public class SecurityConfig {
 
-    private UserDetailsService userDetailsService;
-
     private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     private JwtAuthenticationFilter authenticationFilter;
 
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+
+
     @Bean
-    public static PasswordEncoder passwordEncoder(){
+    public static PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
@@ -46,8 +47,12 @@ public class SecurityConfig {
                     authorize.anyRequest().authenticated();
                 }).httpBasic(Customizer.withDefaults());
 
-        http.exceptionHandling( exception -> exception
-                .authenticationEntryPoint(jwtAuthenticationEntryPoint));
+        http.exceptionHandling(exception -> exception
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .accessDeniedHandler(accessDeniedHandler));
+
+        http.sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         http.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/br/com/zup/taxes/infra/SwaggerConfig.java
+++ b/src/main/java/br/com/zup/taxes/infra/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package br.com.zup.taxes.infra;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,11 +13,19 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI customOpenAPI() {
+        String securitySchemeName = "Bearer Authentication";
         return new OpenAPI()
                 .info(new Info()
                         .title("Taxes API")
                         .version("1.0.0")
-                        .description("Documentação dos endpoints de Taxes API"));
+                        .description("Documentação dos endpoints de Taxes API"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
     }
 
 }

--- a/src/main/java/br/com/zup/taxes/infra/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/br/com/zup/taxes/infra/jwt/JwtAuthenticationFilter.java
@@ -22,15 +22,13 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final UserDetailsService userDetailsService;
-    private final HttpServletRequest httpServletRequest;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
-        String token = getTokenFromRequest();
-
+        String token = getTokenFromRequest(request);
         if(StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)){
             String username = jwtTokenProvider.getUsername(token);
 
@@ -46,8 +44,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private String getTokenFromRequest() {
-        String bearerToken = httpServletRequest.getHeader("Authorization");
+    private String getTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }

--- a/src/main/java/br/com/zup/taxes/infra/jwt/JwtTokenProvider.java
+++ b/src/main/java/br/com/zup/taxes/infra/jwt/JwtTokenProvider.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 @Component
 public class JwtTokenProvider {
     private String jwtSecret = "af60addca9ea3e3c099551e1b6576c9966dce0a33de879dd7e160f86dbd872ca236d6e9ee66fb6e30039fe7c345324a10f3d0741b0600fa7a45df4c6691eff4f4209767ed39f51e37717d8feecd5dd14fc34ebe619e6a29ae91d9ffe134cb5718bec0b3680d6ae7fc09e67763fe7c05d05d3ba69f47211163852633755b7f861132b0c98f8d7c1af9152d547408e676867a0a32fb525a4354180f5fb6b2dc23b5faa4155b8db63385f96259a90b6ee0e74a5b90a4f0f4fa96fafc296c64588b5c009b3829ae2e1d69a1cf7569b50a65fa553350495d18816f785f961c970c0a9cb9c8da25cc5e9fa4a3e9527a132d616b232d1ee21c3bf6dc8d9e3376e2e82c0";
-    private long jwtExpirationDate = 300000000; //5min
+    private long jwtExpirationDate = 300000;
 
     public String generateToken(Authentication authentication) {
 

--- a/src/main/java/br/com/zup/taxes/infra/jwt/JwtTokenProvider.java
+++ b/src/main/java/br/com/zup/taxes/infra/jwt/JwtTokenProvider.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 @Component
 public class JwtTokenProvider {
     private String jwtSecret = "af60addca9ea3e3c099551e1b6576c9966dce0a33de879dd7e160f86dbd872ca236d6e9ee66fb6e30039fe7c345324a10f3d0741b0600fa7a45df4c6691eff4f4209767ed39f51e37717d8feecd5dd14fc34ebe619e6a29ae91d9ffe134cb5718bec0b3680d6ae7fc09e67763fe7c05d05d3ba69f47211163852633755b7f861132b0c98f8d7c1af9152d547408e676867a0a32fb525a4354180f5fb6b2dc23b5faa4155b8db63385f96259a90b6ee0e74a5b90a4f0f4fa96fafc296c64588b5c009b3829ae2e1d69a1cf7569b50a65fa553350495d18816f785f961c970c0a9cb9c8da25cc5e9fa4a3e9527a132d616b232d1ee21c3bf6dc8d9e3376e2e82c0";
-    private long jwtExpirationDate = 300000; //5min
+    private long jwtExpirationDate = 300000000; //5min
 
     public String generateToken(Authentication authentication) {
 
@@ -44,11 +44,11 @@ public class JwtTokenProvider {
         return token;
     }
 
-    private Key key(){
+    private Key key() {
         return Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtSecret));
     }
 
-    public String getUsername(String token){
+    public String getUsername(String token) {
 
         return Jwts.parser()
                 .verifyWith((SecretKey) key())
@@ -58,13 +58,16 @@ public class JwtTokenProvider {
                 .getSubject();
     }
 
-    public boolean validateToken(String token){
-        Jwts.parser()
-                .verifyWith((SecretKey) key())
-                .build()
-                .parse(token);
-        return true;
-
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith((SecretKey) key())
+                    .build()
+                    .parse(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     public UsernamePasswordAuthenticationToken getAuthentication(String token) {

--- a/src/main/java/br/com/zup/taxes/models/Tax.java
+++ b/src/main/java/br/com/zup/taxes/models/Tax.java
@@ -1,0 +1,27 @@
+package br.com.zup.taxes.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "taxes")
+public class Tax {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false, unique = true)
+    private String name;
+    private String description;
+    @Column(nullable = false)
+    private Double aliquot;
+}

--- a/src/main/java/br/com/zup/taxes/repositories/TaxJpaRepository.java
+++ b/src/main/java/br/com/zup/taxes/repositories/TaxJpaRepository.java
@@ -1,0 +1,7 @@
+package br.com.zup.taxes.repositories;
+
+import br.com.zup.taxes.models.Tax;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaxJpaRepository extends JpaRepository<Tax, Long> {
+}

--- a/src/main/java/br/com/zup/taxes/repositories/TaxRepository.java
+++ b/src/main/java/br/com/zup/taxes/repositories/TaxRepository.java
@@ -1,0 +1,8 @@
+package br.com.zup.taxes.repositories;
+
+import br.com.zup.taxes.controllers.dto.TaxDto;
+import br.com.zup.taxes.controllers.dto.TaxResponseDto;
+
+public interface TaxRepository {
+    TaxResponseDto register(TaxDto taxDto);
+}

--- a/src/main/java/br/com/zup/taxes/repositories/TaxRepository.java
+++ b/src/main/java/br/com/zup/taxes/repositories/TaxRepository.java
@@ -9,4 +9,5 @@ public interface TaxRepository {
     TaxResponseDto register(TaxDto taxDto);
     List<TaxResponseDto> findAll();
     TaxResponseDto findById(Long id);
+    void deleteById(Long id);
 }

--- a/src/main/java/br/com/zup/taxes/repositories/TaxRepository.java
+++ b/src/main/java/br/com/zup/taxes/repositories/TaxRepository.java
@@ -3,6 +3,10 @@ package br.com.zup.taxes.repositories;
 import br.com.zup.taxes.controllers.dto.TaxDto;
 import br.com.zup.taxes.controllers.dto.TaxResponseDto;
 
+import java.util.List;
+
 public interface TaxRepository {
     TaxResponseDto register(TaxDto taxDto);
+    List<TaxResponseDto> findAll();
+    TaxResponseDto findById(Long id);
 }

--- a/src/main/java/br/com/zup/taxes/repositories/TaxRepositoryImpl.java
+++ b/src/main/java/br/com/zup/taxes/repositories/TaxRepositoryImpl.java
@@ -1,0 +1,30 @@
+package br.com.zup.taxes.repositories;
+
+import br.com.zup.taxes.controllers.dto.TaxDto;
+import br.com.zup.taxes.controllers.dto.TaxResponseDto;
+import br.com.zup.taxes.models.Tax;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TaxRepositoryImpl implements TaxRepository {
+
+    private final TaxJpaRepository taxJpaRepository;
+    @Override
+    public TaxResponseDto register(TaxDto taxDto) {
+        Tax taxToPersist = new Tax();
+        taxToPersist.setName(taxDto.getName());
+        taxToPersist.setDescription(taxDto.getDescription());
+        taxToPersist.setAliquot(taxDto.getAliquot());
+
+        Tax taxPersisted = taxJpaRepository.save(taxToPersist);
+
+        return TaxResponseDto.builder()
+                .id(taxPersisted.getId())
+                .name(taxPersisted.getName())
+                .description(taxPersisted.getDescription())
+                .aliquot(taxPersisted.getAliquot())
+                .build();
+    }
+}

--- a/src/main/java/br/com/zup/taxes/repositories/TaxRepositoryImpl.java
+++ b/src/main/java/br/com/zup/taxes/repositories/TaxRepositoryImpl.java
@@ -2,15 +2,19 @@ package br.com.zup.taxes.repositories;
 
 import br.com.zup.taxes.controllers.dto.TaxDto;
 import br.com.zup.taxes.controllers.dto.TaxResponseDto;
+import br.com.zup.taxes.exceptions.TaxNotFoundException;
 import br.com.zup.taxes.models.Tax;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class TaxRepositoryImpl implements TaxRepository {
 
     private final TaxJpaRepository taxJpaRepository;
+
     @Override
     public TaxResponseDto register(TaxDto taxDto) {
         Tax taxToPersist = new Tax();
@@ -25,6 +29,26 @@ public class TaxRepositoryImpl implements TaxRepository {
                 .name(taxPersisted.getName())
                 .description(taxPersisted.getDescription())
                 .aliquot(taxPersisted.getAliquot())
+                .build();
+    }
+
+    @Override
+    public List<TaxResponseDto> findAll() {
+        List<Tax> taxes = taxJpaRepository.findAll();
+        return taxes.stream()
+                .map(tax -> new TaxResponseDto(tax.getId(), tax.getName(), tax.getDescription(), tax.getAliquot()))
+                .toList();
+    }
+
+    @Override
+    public TaxResponseDto findById(Long id) {
+        Tax tax = taxJpaRepository.findById(id)
+                .orElseThrow(() -> new TaxNotFoundException("Imposto não cadastrado na base."));
+        return TaxResponseDto.builder()
+                .id(tax.getId())
+                .name(tax.getName())
+                .description(tax.getDescription())
+                .aliquot(tax.getAliquot())
                 .build();
     }
 }

--- a/src/main/java/br/com/zup/taxes/repositories/TaxRepositoryImpl.java
+++ b/src/main/java/br/com/zup/taxes/repositories/TaxRepositoryImpl.java
@@ -51,4 +51,9 @@ public class TaxRepositoryImpl implements TaxRepository {
                 .aliquot(tax.getAliquot())
                 .build();
     }
+
+    @Override
+    public void deleteById(Long id) {
+        taxJpaRepository.deleteById(id);
+    }
 }

--- a/src/main/java/br/com/zup/taxes/services/RolesDataBaseInitializer.java
+++ b/src/main/java/br/com/zup/taxes/services/RolesDataBaseInitializer.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class DataInitializer {
+public class RolesDataBaseInitializer {
 
     private final RoleRepository roleRepository;
 

--- a/src/main/java/br/com/zup/taxes/services/TaxService.java
+++ b/src/main/java/br/com/zup/taxes/services/TaxService.java
@@ -9,4 +9,5 @@ public interface TaxService {
     TaxResponseDto register(TaxDto taxDto);
     List<TaxResponseDto> findAll();
     TaxResponseDto findById(Long id);
+    void deleteById(Long id);
 }

--- a/src/main/java/br/com/zup/taxes/services/TaxService.java
+++ b/src/main/java/br/com/zup/taxes/services/TaxService.java
@@ -1,0 +1,8 @@
+package br.com.zup.taxes.services;
+
+import br.com.zup.taxes.controllers.dto.TaxDto;
+import br.com.zup.taxes.controllers.dto.TaxResponseDto;
+
+public interface TaxService {
+    TaxResponseDto register(TaxDto taxDto);
+}

--- a/src/main/java/br/com/zup/taxes/services/TaxService.java
+++ b/src/main/java/br/com/zup/taxes/services/TaxService.java
@@ -3,6 +3,10 @@ package br.com.zup.taxes.services;
 import br.com.zup.taxes.controllers.dto.TaxDto;
 import br.com.zup.taxes.controllers.dto.TaxResponseDto;
 
+import java.util.List;
+
 public interface TaxService {
     TaxResponseDto register(TaxDto taxDto);
+    List<TaxResponseDto> findAll();
+    TaxResponseDto findById(Long id);
 }

--- a/src/main/java/br/com/zup/taxes/services/TaxServiceImpl.java
+++ b/src/main/java/br/com/zup/taxes/services/TaxServiceImpl.java
@@ -6,6 +6,8 @@ import br.com.zup.taxes.repositories.TaxRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class TaxServiceImpl implements TaxService {
@@ -15,5 +17,15 @@ public class TaxServiceImpl implements TaxService {
     @Override
     public TaxResponseDto register(TaxDto taxDto) {
         return taxRepository.register(taxDto);
+    }
+
+    @Override
+    public List<TaxResponseDto> findAll() {
+        return taxRepository.findAll();
+    }
+
+    @Override
+    public TaxResponseDto findById(Long id) {
+        return taxRepository.findById(id);
     }
 }

--- a/src/main/java/br/com/zup/taxes/services/TaxServiceImpl.java
+++ b/src/main/java/br/com/zup/taxes/services/TaxServiceImpl.java
@@ -28,4 +28,9 @@ public class TaxServiceImpl implements TaxService {
     public TaxResponseDto findById(Long id) {
         return taxRepository.findById(id);
     }
+
+    @Override
+    public void deleteById(Long id) {
+        taxRepository.deleteById(id);
+    }
 }

--- a/src/main/java/br/com/zup/taxes/services/TaxServiceImpl.java
+++ b/src/main/java/br/com/zup/taxes/services/TaxServiceImpl.java
@@ -1,0 +1,19 @@
+package br.com.zup.taxes.services;
+
+import br.com.zup.taxes.controllers.dto.TaxDto;
+import br.com.zup.taxes.controllers.dto.TaxResponseDto;
+import br.com.zup.taxes.repositories.TaxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TaxServiceImpl implements TaxService {
+
+    private final TaxRepository taxRepository;
+
+    @Override
+    public TaxResponseDto register(TaxDto taxDto) {
+        return taxRepository.register(taxDto);
+    }
+}

--- a/src/test/java/br/com/zup/taxes/controllers/TaxControllerIT.java
+++ b/src/test/java/br/com/zup/taxes/controllers/TaxControllerIT.java
@@ -2,6 +2,8 @@ package br.com.zup.taxes.controllers;
 
 import br.com.zup.taxes.infra.BaseIT;
 import br.com.zup.taxes.infra.jwt.JwtTestUtil;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,18 +11,42 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
 @ExtendWith(SpringExtension.class)
-class TaxControllerTest extends BaseIT {
+class TaxControllerIT extends BaseIT {
     @Autowired
     private MockMvc mockMvc;
     @Autowired
     private JwtTestUtil jwtTestUtil;
+    private Long id;
 
+    @BeforeEach
+    public void init() throws Exception {
+        String token = jwtTestUtil.generateToken("testUserAdmin", "ROLE_ADMIN");
+        String requestBody = """
+            {
+                "name": "Tax Name",
+                "description": "Tax Description",
+                "aliquot": 10.0
+            }
+            """;
+
+        MvcResult result = mockMvc.perform(post("/impostos/tipos")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        id = JsonPath.parse(responseBody).read("$.id", Long.class);
+    }
 
 
     @Test
@@ -29,9 +55,9 @@ class TaxControllerTest extends BaseIT {
         String token = jwtTestUtil.generateToken("testUserAdmin", "ROLE_ADMIN");
         String requestBody = """
                 {
-                    "name": "Tax Name",
-                    "description": "Tax Description",
-                    "aliquot": 10.0
+                    "name": "Tax",
+                    "description": "Tax description for test",
+                    "aliquot": 15.0
                 }
                 """;
 
@@ -41,9 +67,9 @@ class TaxControllerTest extends BaseIT {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.name").value("Tax Name"))
-                .andExpect(jsonPath("$.description").value("Tax Description"))
-                .andExpect(jsonPath("$.aliquot").value(10.0));
+                .andExpect(jsonPath("$.name").value("Tax"))
+                .andExpect(jsonPath("$.description").value("Tax description for test"))
+                .andExpect(jsonPath("$.aliquot").value(15.0));
     }
 
     @Test
@@ -103,7 +129,57 @@ class TaxControllerTest extends BaseIT {
                         .content(requestBody))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.mensagem").value("Credenciais inválidas."));
+    }
 
+    @Test
+    public void shouldReturnAllTaxTypesSuccessfully_withAdminRole() throws Exception {
+        // Arrange
+        String token = jwtTestUtil.generateToken("testUserAdmin", "ROLE_ADMIN");
 
+        // Act & Assert
+        mockMvc.perform(get("/impostos/tipos")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isNotEmpty());
+    }
+
+    @Test
+    public void shouldReturnTaxTypeByIdSuccessfully_withAdminRole() throws Exception {
+        // Arrange
+        String token = jwtTestUtil.generateToken("testUserAdmin", "ROLE_ADMIN");
+        Long taxId = id;
+
+        // Act & Assert
+        mockMvc.perform(get("/impostos/tipos/{id}", taxId)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(id))
+                .andExpect(jsonPath("$.name").value("Tax Name"))
+                .andExpect(jsonPath("$.description").value("Tax Description"))
+                .andExpect(jsonPath("$.aliquot").value(10.0));
+    }
+
+    @Test
+    public void shouldReturnNotFound_whenTaxTypeDoesNotExist_withAdminRole() throws Exception {
+        // Arrange
+        String token = jwtTestUtil.generateToken("testUserAdmin", "ROLE_ADMIN");
+        Long taxId = 999L;
+
+        // Act & Assert
+        mockMvc.perform(get("/impostos/tipos/{id}", taxId)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.mensagem").value("Imposto não cadastrado na base."));
+    }
+
+    @Test
+    public void shouldReturnUnauthorized_whenNoTokenProvided_forFindAll() throws Exception {
+        // Act & Assert
+        mockMvc.perform(get("/impostos/tipos")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/br/com/zup/taxes/controllers/TaxControllerIT.java
+++ b/src/test/java/br/com/zup/taxes/controllers/TaxControllerIT.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -181,5 +182,56 @@ class TaxControllerIT extends BaseIT {
         mockMvc.perform(get("/impostos/tipos")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void shouldDeleteTaxSuccessfully_withAdminRole() throws Exception {
+        // Arrange
+        String token = jwtTestUtil.generateToken("testUserAdmin", "ROLE_ADMIN");
+        Long taxId = id;
+
+        // Act & Assert
+        mockMvc.perform(delete("/impostos/tipos/{id}", taxId)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void shouldReturnForbidden_whenUserRoleTriesToDelete() throws Exception {
+        // Arrange
+        String token = jwtTestUtil.generateToken("testUser", "ROLE_USER");
+        Long taxId = id;
+
+        // Act & Assert
+        mockMvc.perform(delete("/impostos/tipos/{id}", taxId)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void shouldReturnUnauthorized_whenNoTokenProvided_forDelete() throws Exception {
+        // Arrange
+        Long taxId = id;
+
+        // Act & Assert
+        mockMvc.perform(delete("/impostos/tipos/{id}", taxId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void shouldReturnUnauthorized_whenTokenIsInvalid_forDelete() throws Exception {
+        // Arrange
+        String invalidToken = jwtTestUtil.generateInvalidToken();
+        Long taxId = id;
+
+        // Act & Assert
+        mockMvc.perform(delete("/impostos/tipos/{id}", taxId)
+                        .header("Authorization", "Bearer " + invalidToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.mensagem").value("Credenciais inválidas."));
     }
 }

--- a/src/test/java/br/com/zup/taxes/controllers/TaxControllerTest.java
+++ b/src/test/java/br/com/zup/taxes/controllers/TaxControllerTest.java
@@ -1,0 +1,109 @@
+package br.com.zup.taxes.controllers;
+
+import br.com.zup.taxes.infra.BaseIT;
+import br.com.zup.taxes.infra.jwt.JwtTestUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@ExtendWith(SpringExtension.class)
+class TaxControllerTest extends BaseIT {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private JwtTestUtil jwtTestUtil;
+
+
+
+    @Test
+    public void shouldRegisterTaxSuccessfully_withAdminRole() throws Exception {
+        // Arrange
+        String token = jwtTestUtil.generateToken("testUserAdmin", "ROLE_ADMIN");
+        String requestBody = """
+                {
+                    "name": "Tax Name",
+                    "description": "Tax Description",
+                    "aliquot": 10.0
+                }
+                """;
+
+        // Act & Assert
+        mockMvc.perform(post("/impostos/tipos")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Tax Name"))
+                .andExpect(jsonPath("$.description").value("Tax Description"))
+                .andExpect(jsonPath("$.aliquot").value(10.0));
+    }
+
+    @Test
+    public void shouldReturnForbidden_withUserRole() throws Exception {
+        // Arrange
+        String token = jwtTestUtil.generateToken("testUser", "ROLE_USER");
+        String requestBody = """
+                {
+                    "name": "Tax Name",
+                    "description": "Tax Description",
+                    "aliquot": 10.0
+                }
+                """;
+
+        // Act & Assert
+        mockMvc.perform(post("/impostos/tipos")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void shouldReturnUnauthorized_whenNoTokenProvided() throws Exception {
+        // Arrange
+        String requestBody = """
+                {
+                    "name": "Tax Name",
+                    "description": "Tax Description",
+                    "aliquot": 10.0
+                }
+                """;
+
+        // Act & Assert
+        mockMvc.perform(post("/impostos/tipos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void shouldReturnUnauthorized_whenTokenIsInvalid() throws Exception {
+        // Arrange
+        String invalidToken = jwtTestUtil.generateInvalidToken();
+        String requestBody = """
+                {
+                    "name": "Tax Name",
+                    "description": "Tax Description",
+                    "aliquot": 10.0
+                }
+                """;
+
+        // Act & Assert
+        mockMvc.perform(post("/impostos/tipos")
+                        .header("Authorization", "Bearer " + invalidToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.mensagem").value("Credenciais inválidas."));
+
+
+    }
+}

--- a/src/test/java/br/com/zup/taxes/controllers/UserControllerIT.java
+++ b/src/test/java/br/com/zup/taxes/controllers/UserControllerIT.java
@@ -22,7 +22,7 @@ class UserControllerIT extends BaseIT {
     public void mustRegisterUserSuccessfully() throws Exception {
         String requestBody = """
                     {
-                        "userName": "test_user",
+                        "userName": "test_userAdmin",
                         "password": "12345",
                         "role": "ROLE_ADMIN"
                     }
@@ -31,7 +31,7 @@ class UserControllerIT extends BaseIT {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.usuario").value("test_user"));
+                .andExpect(jsonPath("$.usuario").value("test_userAdmin"));
 
     }
 
@@ -39,7 +39,7 @@ class UserControllerIT extends BaseIT {
     public void shouldReturnBadRequest_userRegistered() throws Exception {
         String requestBody = """
                     {
-                        "userName": "testUser",
+                        "userName": "testUserAdmin",
                         "password": "12345",
                         "role": "ROLE_ADMIN"
                     }
@@ -56,7 +56,7 @@ class UserControllerIT extends BaseIT {
     public void shouldReturnBadRequest_roleNotFound() throws Exception {
         String requestBody = """
                     {
-                        "userName": "test_user",
+                        "userName": "test_userAdmin",
                         "password": "12345",
                         "role": "ROLE_NEW"
                     }
@@ -72,7 +72,7 @@ class UserControllerIT extends BaseIT {
     public void mustLoginSuccessfully() throws Exception {
         String requestBody = """
                     {
-                        "userName": "testUser",
+                        "userName": "testUserAdmin",
                         "password": "testPassword"
                     }
                 """;
@@ -87,7 +87,7 @@ class UserControllerIT extends BaseIT {
     public void shouldReturnUnathorized_BadCredentials() throws Exception {
         String requestBody = """
                     {
-                        "userName": "testUser",
+                        "userName": "testUserAdmin",
                         "password": "12345"
                     }
                 """;

--- a/src/test/java/br/com/zup/taxes/infra/BaseIT.java
+++ b/src/test/java/br/com/zup/taxes/infra/BaseIT.java
@@ -21,11 +21,15 @@ public abstract class BaseIT {
 
     @BeforeEach
     public void setUp() {
+        createUser("testUserAdmin", RoleEnum.ROLE_ADMIN);
+        createUser("testUser", RoleEnum.ROLE_USER);
+    }
 
-        if (!userRepository.existsByUserName("testUser")) {
+    private void createUser(String name, RoleEnum role) {
+        if (!userRepository.existsByUserName(name)) {
             RegisterUserDto user = new RegisterUserDto();
-            user.setUserName("testUser");
-            user.setRole(RoleEnum.ROLE_ADMIN);
+            user.setUserName(name);
+            user.setRole(role);
             user.setPassword(passwordEncoder.encode("testPassword"));
 
             userRepository.save(user);

--- a/src/test/java/br/com/zup/taxes/infra/SecurityConfigTest.java
+++ b/src/test/java/br/com/zup/taxes/infra/SecurityConfigTest.java
@@ -19,6 +19,8 @@ class SecurityConfigTest {
     private JwtAuthenticationEntryPoint authenticationEntryPoint;
     @Mock
     private JwtAuthenticationFilter authenticationFilter;
+    @Mock
+    private CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Test
     void passwordEncoderBeanShouldBeBCryptPasswordEncoder() {
@@ -31,7 +33,7 @@ class SecurityConfigTest {
 
     @Test
     void securityFilterChainShouldBeConfigured() throws Exception {
-        SecurityConfig securityConfig = new SecurityConfig(null, authenticationEntryPoint, authenticationFilter);
+        SecurityConfig securityConfig = new SecurityConfig(authenticationEntryPoint, authenticationFilter, customAccessDeniedHandler);
 
         HttpSecurity httpSecurity = mock(HttpSecurity.class, RETURNS_DEEP_STUBS);
 

--- a/src/test/java/br/com/zup/taxes/infra/jwt/JwtTestUtil.java
+++ b/src/test/java/br/com/zup/taxes/infra/jwt/JwtTestUtil.java
@@ -1,0 +1,31 @@
+package br.com.zup.taxes.infra.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTestUtil {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+
+    public String generateToken(String username, String role) {
+        Collection<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(role));
+        Authentication authentication = new UsernamePasswordAuthenticationToken(username, null, authorities);
+        return jwtTokenProvider.generateToken(authentication);
+    }
+
+    public String generateInvalidToken() {
+        String validToken = generateToken("testUser", "ROLE_USER");
+
+        return validToken.substring(0, validToken.length() - 1) + "x";
+    }
+}

--- a/src/test/java/br/com/zup/taxes/infra/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/br/com/zup/taxes/infra/jwt/JwtTokenProviderTest.java
@@ -64,7 +64,7 @@ class JwtTokenProviderTest {
         String invalidToken = "invalid.token.value";
 
         // Act & Assert
-        assertThrows(Exception.class, () -> jwtTokenProvider.validateToken(invalidToken));
+        assertFalse(jwtTokenProvider.validateToken(invalidToken));
     }
 
     @Test

--- a/src/test/java/br/com/zup/taxes/repositories/TaxRepositoryImplTest.java
+++ b/src/test/java/br/com/zup/taxes/repositories/TaxRepositoryImplTest.java
@@ -2,8 +2,10 @@ package br.com.zup.taxes.repositories;
 
 import br.com.zup.taxes.controllers.dto.TaxDto;
 import br.com.zup.taxes.controllers.dto.TaxResponseDto;
+import br.com.zup.taxes.exceptions.TaxNotFoundException;
 import br.com.zup.taxes.models.Tax;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.ArgumentMatchers.any;
@@ -11,6 +13,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class TaxRepositoryImplTest {
@@ -50,5 +56,72 @@ class TaxRepositoryImplTest {
         assertEquals("Tax Name", response.getName());
         assertEquals("Tax Description", response.getDescription());
         assertEquals(10.0, response.getAliquot());
+    }
+
+    @Test
+    void testFindAll_ShouldReturnListOfTaxResponseDto() {
+        // Arrange
+        Tax tax1 = new Tax();
+        tax1.setId(1L);
+        tax1.setName("Tax 1");
+        tax1.setDescription("Description 1");
+        tax1.setAliquot(5.0);
+
+        Tax tax2 = new Tax();
+        tax2.setId(2L);
+        tax2.setName("Tax 2");
+        tax2.setDescription("Description 2");
+        tax2.setAliquot(10.0);
+
+        when(taxJpaRepository.findAll()).thenReturn(Arrays.asList(tax1, tax2));
+
+        // Act
+        List<TaxResponseDto> response = taxRepositoryImpl.findAll();
+
+        // Assert
+        assertEquals(2, response.size());
+
+        assertEquals(1L, response.get(0).getId());
+        assertEquals("Tax 1", response.get(0).getName());
+        assertEquals("Description 1", response.get(0).getDescription());
+        assertEquals(5.0, response.get(0).getAliquot());
+
+        assertEquals(2L, response.get(1).getId());
+        assertEquals("Tax 2", response.get(1).getName());
+        assertEquals("Description 2", response.get(1).getDescription());
+        assertEquals(10.0, response.get(1).getAliquot());
+    }
+
+    @Test
+    void testFindById_ShouldReturnTaxResponseDto_WhenTaxExists() {
+        // Arrange
+        Long taxId = 1L;
+        Tax tax = new Tax();
+        tax.setId(taxId);
+        tax.setName("Tax Name");
+        tax.setDescription("Tax Description");
+        tax.setAliquot(10.0);
+
+        when(taxJpaRepository.findById(taxId)).thenReturn(Optional.of(tax));
+
+        // Act
+        TaxResponseDto response = taxRepositoryImpl.findById(taxId);
+
+        // Assert
+        assertEquals(taxId, response.getId());
+        assertEquals("Tax Name", response.getName());
+        assertEquals("Tax Description", response.getDescription());
+        assertEquals(10.0, response.getAliquot());
+    }
+
+    @Test
+    void testFindById_ShouldThrowTaxNotFoundException_WhenTaxDoesNotExist() {
+        // Arrange
+        Long taxId = 999L;
+        when(taxJpaRepository.findById(taxId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        TaxNotFoundException exception = assertThrows(TaxNotFoundException.class, () -> taxRepositoryImpl.findById(taxId));
+        assertEquals("Imposto não cadastrado na base.", exception.getMessage());
     }
 }

--- a/src/test/java/br/com/zup/taxes/repositories/TaxRepositoryImplTest.java
+++ b/src/test/java/br/com/zup/taxes/repositories/TaxRepositoryImplTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.ArgumentMatchers.any;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -123,5 +125,17 @@ class TaxRepositoryImplTest {
         // Act & Assert
         TaxNotFoundException exception = assertThrows(TaxNotFoundException.class, () -> taxRepositoryImpl.findById(taxId));
         assertEquals("Imposto não cadastrado na base.", exception.getMessage());
+    }
+
+    @Test
+    void testDeleteById_ShouldDeleteTaxSuccessfully() {
+        // Arrange
+        Long taxId = 1L;
+
+        // Act
+        taxRepositoryImpl.deleteById(taxId);
+
+        // Assert
+        verify(taxJpaRepository, times(1)).deleteById(taxId);
     }
 }

--- a/src/test/java/br/com/zup/taxes/repositories/TaxRepositoryImplTest.java
+++ b/src/test/java/br/com/zup/taxes/repositories/TaxRepositoryImplTest.java
@@ -1,0 +1,54 @@
+package br.com.zup.taxes.repositories;
+
+import br.com.zup.taxes.controllers.dto.TaxDto;
+import br.com.zup.taxes.controllers.dto.TaxResponseDto;
+import br.com.zup.taxes.models.Tax;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TaxRepositoryImplTest {
+
+    @Mock
+    private TaxJpaRepository taxJpaRepository;
+
+    @InjectMocks
+    private TaxRepositoryImpl taxRepositoryImpl;
+
+    @Test
+    void testRegister_ShouldPersistTaxAndReturnResponseDto() {
+        // Arrange
+        TaxDto taxDto = new TaxDto();
+        taxDto.setName("Tax Name");
+        taxDto.setDescription("Tax Description");
+        taxDto.setAliquot(10.0);
+
+        Tax taxToPersist = new Tax();
+        taxToPersist.setName(taxDto.getName());
+        taxToPersist.setDescription(taxDto.getDescription());
+        taxToPersist.setAliquot(taxDto.getAliquot());
+
+        Tax taxPersisted = new Tax();
+        taxPersisted.setId(1L);
+        taxPersisted.setName(taxDto.getName());
+        taxPersisted.setDescription(taxDto.getDescription());
+        taxPersisted.setAliquot(taxDto.getAliquot());
+
+        when(taxJpaRepository.save(any(Tax.class))).thenReturn(taxPersisted);
+
+        // Act
+        TaxResponseDto response = taxRepositoryImpl.register(taxDto);
+
+        // Assert
+        assertEquals(1L, response.getId());
+        assertEquals("Tax Name", response.getName());
+        assertEquals("Tax Description", response.getDescription());
+        assertEquals(10.0, response.getAliquot());
+    }
+}

--- a/src/test/java/br/com/zup/taxes/services/TaxServiceImplTest.java
+++ b/src/test/java/br/com/zup/taxes/services/TaxServiceImplTest.java
@@ -2,8 +2,10 @@ package br.com.zup.taxes.services;
 
 import br.com.zup.taxes.controllers.dto.TaxDto;
 import br.com.zup.taxes.controllers.dto.TaxResponseDto;
+import br.com.zup.taxes.exceptions.TaxNotFoundException;
 import br.com.zup.taxes.repositories.TaxRepository;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -13,18 +15,20 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(value = MockitoExtension.class)
+import java.util.List;
 
+@ExtendWith(value = MockitoExtension.class)
 class TaxServiceImplTest {
 
     @Mock
     private TaxRepository taxRepository;
+
     @InjectMocks
     private TaxServiceImpl taxService;
 
     @Test
     void shouldRegisterTaxSuccessfully() {
-        //Arrange
+        // Arrange
         TaxDto taxDto = new TaxDto();
         TaxResponseDto responseDto = TaxResponseDto.builder()
                 .id(1L)
@@ -35,14 +39,87 @@ class TaxServiceImplTest {
 
         when(taxRepository.register(taxDto)).thenReturn(responseDto);
 
-        //Act
+        // Act
         TaxResponseDto result = taxService.register(taxDto);
 
-        //Assert
+        // Assert
         assertEquals(responseDto.getId(), result.getId());
         assertEquals(responseDto.getName(), result.getName());
         assertEquals(responseDto.getDescription(), result.getDescription());
         assertEquals(responseDto.getAliquot(), result.getAliquot());
         verify(taxRepository, times(1)).register(taxDto);
+    }
+
+    @Test
+    void shouldReturnAllTaxesSuccessfully() {
+        // Arrange
+        TaxResponseDto tax1 = TaxResponseDto.builder()
+                .id(1L)
+                .name("Tax 1")
+                .description("Description 1")
+                .aliquot(5.0)
+                .build();
+
+        TaxResponseDto tax2 = TaxResponseDto.builder()
+                .id(2L)
+                .name("Tax 2")
+                .description("Description 2")
+                .aliquot(10.0)
+                .build();
+
+        List<TaxResponseDto> taxes = List.of(tax1, tax2);
+
+        when(taxRepository.findAll()).thenReturn(taxes);
+
+        // Act
+        List<TaxResponseDto> result = taxService.findAll();
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals(tax1.getId(), result.get(0).getId());
+        assertEquals(tax1.getName(), result.get(0).getName());
+        assertEquals(tax1.getDescription(), result.get(0).getDescription());
+        assertEquals(tax1.getAliquot(), result.get(0).getAliquot());
+        assertEquals(tax2.getId(), result.get(1).getId());
+        assertEquals(tax2.getName(), result.get(1).getName());
+        assertEquals(tax2.getDescription(), result.get(1).getDescription());
+        assertEquals(tax2.getAliquot(), result.get(1).getAliquot());
+        verify(taxRepository, times(1)).findAll();
+    }
+
+    @Test
+    void shouldReturnTaxByIdSuccessfully() {
+        // Arrange
+        Long taxId = 1L;
+        TaxResponseDto responseDto = TaxResponseDto.builder()
+                .id(taxId)
+                .name("Tax name")
+                .description("Tax description")
+                .aliquot(1.0)
+                .build();
+
+        when(taxRepository.findById(taxId)).thenReturn(responseDto);
+
+        // Act
+        TaxResponseDto result = taxService.findById(taxId);
+
+        // Assert
+        assertEquals(responseDto.getId(), result.getId());
+        assertEquals(responseDto.getName(), result.getName());
+        assertEquals(responseDto.getDescription(), result.getDescription());
+        assertEquals(responseDto.getAliquot(), result.getAliquot());
+        verify(taxRepository, times(1)).findById(taxId);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTaxNotFoundById() {
+        // Arrange
+        Long taxId = 999L;
+        when(taxRepository.findById(taxId)).thenThrow(new TaxNotFoundException("Imposto não cadastrado na base."));
+
+        // Act & Assert
+        TaxNotFoundException exception = assertThrows(TaxNotFoundException.class, () -> taxService.findById(taxId));
+        assertEquals("Imposto não cadastrado na base.", exception.getMessage());
+        verify(taxRepository, times(1)).findById(taxId);
     }
 }

--- a/src/test/java/br/com/zup/taxes/services/TaxServiceImplTest.java
+++ b/src/test/java/br/com/zup/taxes/services/TaxServiceImplTest.java
@@ -1,0 +1,48 @@
+package br.com.zup.taxes.services;
+
+import br.com.zup.taxes.controllers.dto.TaxDto;
+import br.com.zup.taxes.controllers.dto.TaxResponseDto;
+import br.com.zup.taxes.repositories.TaxRepository;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(value = MockitoExtension.class)
+
+class TaxServiceImplTest {
+
+    @Mock
+    private TaxRepository taxRepository;
+    @InjectMocks
+    private TaxServiceImpl taxService;
+
+    @Test
+    void shouldRegisterTaxSuccessfully() {
+        //Arrange
+        TaxDto taxDto = new TaxDto();
+        TaxResponseDto responseDto = TaxResponseDto.builder()
+                .id(1L)
+                .name("Tax name")
+                .description("Tax description")
+                .aliquot(1.0)
+                .build();
+
+        when(taxRepository.register(taxDto)).thenReturn(responseDto);
+
+        //Act
+        TaxResponseDto result = taxService.register(taxDto);
+
+        //Assert
+        assertEquals(responseDto.getId(), result.getId());
+        assertEquals(responseDto.getName(), result.getName());
+        assertEquals(responseDto.getDescription(), result.getDescription());
+        assertEquals(responseDto.getAliquot(), result.getAliquot());
+        verify(taxRepository, times(1)).register(taxDto);
+    }
+}

--- a/src/test/java/br/com/zup/taxes/services/TaxServiceImplTest.java
+++ b/src/test/java/br/com/zup/taxes/services/TaxServiceImplTest.java
@@ -122,4 +122,16 @@ class TaxServiceImplTest {
         assertEquals("Imposto não cadastrado na base.", exception.getMessage());
         verify(taxRepository, times(1)).findById(taxId);
     }
+
+    @Test
+    void shouldDeleteTaxSuccessfully() {
+        // Arrange
+        Long taxId = 1L;
+
+        // Act
+        taxService.deleteById(taxId);
+
+        // Assert
+        verify(taxRepository, times(1)).deleteById(taxId);
+    }
 }


### PR DESCRIPTION
Este PR implementa as seguintes funcionalidades:

**Endpoints CRUD para Impostos:**
- GET /impostos/tipos
- GET /impostos/tipos/{id}
- POST/impostos/tipos
- DELETE /impostos/tipos/{id}

**Implementação de autenticação JWT para swagger.**
- Agora podemos usar a autenticação jwt para consumir endpoints protegidos diretamente pelo swagger

Documentação que auxiliou na implementação do JWT no swagger:
https://www.baeldung.com/spring-boot-swagger-jwt
